### PR TITLE
Typos and grammar nits

### DIFF
--- a/docs/tc53.md
+++ b/docs/tc53.md
@@ -72,7 +72,7 @@ A single integrated circuit with one or more CPUs, memory, and programmable inpu
 A system of rules that define how data is exchanged between systems.
     
 ##### Register
-Locations in a device's memory which can be written to or read from. These memory locations may contain configuration settings or the current state of the device.
+Locations in a device's memory that can be written to or read from. These memory locations may contain configuration settings or the current state of the device.
 
 ##### Sensor
 A device that detects and responds to some type of input from the physical environment. 

--- a/docs/tc53.md
+++ b/docs/tc53.md
@@ -6,7 +6,7 @@
 
 ## Introduction
 
-This standard, ECMAScript Modules for Embedded Systems, defines APIs for use on embedded systems. Embedded systems are far more diverse than personal computers, smart phones, and web servers where ECMAScript is most widely used. The diversity of embedded hardware is a consequence of devices being optimized for a specific product or class of products.
+This standard, ECMAScript Modules for Embedded Systems, defines APIs for use on embedded systems. Embedded systems are far more diverse than personal computers, smartphones, and web servers where ECMAScript is most widely used. The diversity of embedded hardware is a consequence of devices being optimized for a specific product or class of products.
 
 It is not enough for these APIs to support the features embedded systems have in common. To be truly useful, they must allow access to the unique hardware capabilities of each embedded system. This requirement makes this standard very different from that of a computer language which is grounded in the formality and rigor of mathematics. Hardware can be inconsistent, even sometimes messy, but it needs to be accommodated. 
 
@@ -359,19 +359,19 @@ import DigitalBank from "tc53:io/digitalbank";
 
 | Property | Description |
 | :---: | :--- |
-| `pins` | A bit mask with pins to include in the bank set to 1. This property is required.
+| `pins` | A bitmask with pins to include in the bank set to 1. This property is required.
 | `mode` | A value indicating the mode of the IO, May be `Digital.Input`, `Digital.InputPullUp`, `Digital.InputPullDown`, `Digital.InputPullUpDown`, `Digital.Output`, or `Digital.OutputOpenDrain`. All pins in the bank use the same mode. This property is required.
-| `rises` | A bit mask indicating the pins in the bank that should trigger an `onReadable` callback when transitioning from 0 to 1. When an `onReadable` callback is provided, at least one pin must be set in `rises` and `falls`.
-| `falls` | A bit mask indicating the pins in the bank that should trigger an `onReadable` callback when transitioning from 1 to 0. When an `onReadable` callback is provided, at least one pin must be set in `rises` and `falls`.
+| `rises` | A bitmask indicating the pins in the bank that should trigger an `onReadable` callback when transitioning from 0 to 1. When an `onReadable` callback is provided, at least one pin must be set in `rises` and `falls`.
+| `falls` | A bitmask indicating the pins in the bank that should trigger an `onReadable` callback when transitioning from 1 to 0. When an `onReadable` callback is provided, at least one pin must be set in `rises` and `falls`.
 
 #### Callbacks
 
 **`onReadable(triggers)`**
 
-Invoked when the input value changes depending on the value of the `mode`, `rises`, and `falls` properties. The `onReadable` callback receives a single argument, `triggers`, which is a bit mask indicating each pin that triggered the callback with a 1.
+Invoked when the input value changes depending on the value of the `mode`, `rises`, and `falls` properties. The `onReadable` callback receives a single argument, `triggers`, which is a bitmask indicating each pin that triggered the callback with a 1.
 
 #### Data format
-The `DigitalBank` class data format is always `number`. The value is a bit mask. On a read operation, any bit positions that are not included in the `pins` bit mask are set to 0.
+The `DigitalBank` class data format is always `number`. The value is a bitmask. On a read operation, any bit positions that are not included in the `pins` bitmask are set to 0.
 
 > **Note:** This requirement prevents leaking the state of pins unused by this bank.
 

--- a/docs/tc53.md
+++ b/docs/tc53.md
@@ -1277,7 +1277,7 @@ let spi = new hostProvider.io.SPI(hostProvider.spi.default);
 ```
 
 ### IO providers
-The host provider instance may provide access to IO Providers constructors through its `providers` property.
+The host provider instance may provide access to IO Provider constructors through its `providers` property.
 
 ### sensors
 The host provider instance may provide access to Sensor constructors through its `sensor` property.

--- a/docs/tc53.md
+++ b/docs/tc53.md
@@ -651,7 +651,7 @@ The `onError ` callback is invoked when an error is detected, for example, under
 
 
 ### TCP cocket
-The `TCP` network socket class implements a general purpose, bi-directional TCP connection. 
+The `TCP` network socket class implements a general-purpose, bi-directional TCP connection. 
 
 ```js
 import TCP from "tc53:io/socket/tcp";
@@ -1056,7 +1056,7 @@ The Display Class Pattern is designed to support displays independent of hardwar
 
 Following the Peripheral Class Pattern, the constructor has a single options object argument. The options object defines the hardware connections of the display. These use the same properties as the IO types corresponding to the hardware connection.
 
-A Display Class is not required to have properties to configure its hardware connections. For example, a memory mapped display may have no external connections. Or, a Display Class may be preconfigured for the hardware of a specific host.
+A Display Class is not required to have properties to configure its hardware connections. For example, a memory-mapped display may have no external connections. Or, a Display Class may be preconfigured for the hardware of a specific host.
 
 ### `configure` method
 

--- a/docs/tc53.md
+++ b/docs/tc53.md
@@ -30,7 +30,7 @@ A conforming implementation of the ECMAScript Modules for Embedded Systems stand
 
 A conforming implementation of the ECMAScript Modules for Embedded Systems standard is permitted to provide additional objects, properties, and functions beyond those described in this specification.
 
-In particular, a conforming implementation of the this standard is permitted to provide properties not described herein, and values for those properties, for objects that are described in this specification. A conforming implementation is permitted to add optional arguments to the functions defined in this specification only where noted. 
+In particular, a conforming implementation of this standard is permitted to provide properties not described herein, and values for those properties, for objects that are described in this specification. A conforming implementation is permitted to add optional arguments to the functions defined in this specification only where noted. 
 
 Because implementation differences are permitted (for example, to accommodate differentiating hardware features), this standard does not guarantee that all scripts execute correctly on every conformant deployment.
  
@@ -72,7 +72,7 @@ A single integrated circuit with one or more CPUs, memory, and programmable inpu
 A system of rules that define how data is exchanged between systems.
     
 ##### Register
-Locations in a device's memory which can be written to or read from. These memory locations may contain configuration settings or current state of the device.
+Locations in a device's memory which can be written to or read from. These memory locations may contain configuration settings or the current state of the device.
 
 ##### Sensor
 A device that detects and responds to some type of input from the physical environment. 
@@ -272,7 +272,7 @@ The `write` method sends data to the IO instance.
 
 The following conditions cause an `Error` exception to be thrown: the device cannot accept the data because its buffers are full, the data is incompatible, or a hardware error.
 
-Th `write` method may take any number of arguments, including zero. The arguments are defined by the specific IO type. The type of data accepted by `write` depends on the value of the `format` property.
+The `write` method may take any number of arguments, including zero. The arguments are defined by the specific IO type. The type of data accepted by `write` depends on the value of the `format` property.
 
 If this instance does not support writing (because the IO type cannot be written or because it is configured for read-only) an `Error` exception is thrown.
 
@@ -487,7 +487,7 @@ Writes the unsigned 16-bit integer value to the specified register. By default t
 
 **`readBuffer(register, buffer)`**
 
-Reads a stream of bytes starting at the specified `register` into the `ArrayBuffer` instance in the `buffer` argument . The number of bytes read is equal to the `byteLength` of the buffer.
+Reads a stream of bytes starting at the specified `register` into the `ArrayBuffer` instance in the `buffer` argument. The number of bytes read is equal to the `byteLength` of the buffer.
 
 **`writeBuffer(register, buffer)`**
 
@@ -796,7 +796,7 @@ Following the Base Class Pattern, the constructor has a single options object ar
 The options object is not limited to IO connection information, and must contain all information needed by the implementation to establish the connection.
 
 ### `close` method
-In addition to releasing all resources as required by the Base Class Pattern, the `close` method cause  the `onError` callback to be invoked on all open instances. Note that `onError` may not be invoked from within `close` (see Callbacks section).
+In addition to releasing all resources as required by the Base Class Pattern, the `close` method causes the `onError` callback to be invoked on all open instances. Note that `onError` may not be invoked from within `close` (see Callbacks section).
 
 ### Callbacks
 
@@ -868,7 +868,7 @@ The `configure` method follows the same rules regarding the options argument as 
 
 Because peripherals have many features, the `configure` method may implement support for many properties. A given call to the `configure` method should only modify the features specified in the options object. 
 
-The Peripheral Class Pattern does not require a script call the `configure` method to use the peripheral, however specific implementations may require `configure` be called.
+The Peripheral Class Pattern does not require a script call the `configure` method to use the peripheral, however specific implementations may require `configure` to be called.
 
 The `configure` method may be called more than once to allow scripts to reconfigure the peripheral.
 
@@ -967,7 +967,7 @@ The classes support common sensor capabilities. Capabilities that are not suppor
 
 The `Accelerometer` class implements access to a three-dimensional accelerometer. 
 
-#### Properties of sample object
+#### Properties of a sample object
 These properties are compatible with the attributes of the same name in the [W3C Accelerometer draft](https://w3c.github.io/accelerometer/).
 
 | Property | Description |
@@ -991,7 +991,7 @@ These properties are compatible with the attributes of the same name in the  [W3
 
 The `AtmosphericPressure` class implements access to an atmospheric pressure sensor or barometer.
 
-#### Properties of sample object
+#### Properties of a sample object
 
 | Property | Description |
 | :---: | :--- |
@@ -1001,7 +1001,7 @@ The `AtmosphericPressure` class implements access to an atmospheric pressure sen
 
 The `Humidity` class implements access to a humidity sensor.
 
-#### Properties of sample object
+#### Properties of a sample object
 
 | Property | Description |
 | :---: | :--- |
@@ -1011,7 +1011,7 @@ The `Humidity` class implements access to a humidity sensor.
 
 The `Proximity` class implements access to a proximity sensor or range finder.
 
-#### Properties of sample object
+#### Properties of a sample object
 These properties are compatible with the attributes of the same name in the  [W3C Proximity Sensor draft](https://w3c.github.io/proximity/).
 
 | Property | Description |
@@ -1024,7 +1024,7 @@ These properties are compatible with the attributes of the same name in the  [W3
 
 The `Temperature` class implements access to a temperature sensor.
 
-#### Properties of sample object
+#### Properties of a sample object
 
 | Property | Description |
 | :---: | :--- |
@@ -1070,7 +1070,7 @@ The following table enumerates the properties defined for the options object arg
 | `flip` | A string indicating whether the pixels should be flipped horizontally and/or vertically. Allowed values are `""`, `"h"`, `"v"`, and `"hv"`. The empty string indicates that neither horizontal nor vertical flip is applied. This property is optional.
 
 <!--
-| `colorTable` | A `Uint8Array` containing a packed array of RGB color values (8-bits per channel) to define the color table for indexed displays . This property is optional. 
+| `colorTable` | A `Uint8Array` containing a packed array of RGB color values (8-bits per channel) to define the color table for indexed displays. This property is optional. 
 -->
 
 Note that no default values are defined by the Display Class Pattern for these configuration properties to allow the host to provide default values that are appropriate for its hardware.
@@ -1109,7 +1109,7 @@ The `end` method finishes the process of updating the display's pixels, by makin
 
 ### `adaptInvalid` method
 
-The `adaptInvalid` method accept a single options object argument that includes `x`, `y`, `width`, and `height` properties that describe an area of the display to be updated. It adjusts these properties as necessary so that the result is valid for the display and encloses the original update area.
+The `adaptInvalid` method accepts a single options object argument that includes `x`, `y`, `width`, and `height` properties that describe an area of the display to be updated. It adjusts these properties as necessary so that the result is valid for the display and encloses the original update area.
 
 Consider a display which limits the update area horizontally to even pixel positions. The following code calls a display's `adaptInvalid` method with odd numbers for both left and right edges of the update area:
 

--- a/docs/tc53.md
+++ b/docs/tc53.md
@@ -26,7 +26,7 @@ This standard does not make any changes to the ECMAScript language as defined by
 
 ## 2 Conformance
 
-A conforming implementation of the ECMAScript Modules for Embedded Systems standard must conform to ECMA-262, and must provide and support all the objects, properties, functions, and program semantics required by this specification.
+A conforming implementation of the ECMAScript Modules for Embedded Systems standard must conform to ECMA-262 and must provide and support all the objects, properties, functions, and program semantics required by this specification.
 
 A conforming implementation of the ECMAScript Modules for Embedded Systems standard is permitted to provide additional objects, properties, and functions beyond those described in this specification.
 
@@ -54,7 +54,7 @@ An identifier for interfacing with a specific component, device, or board.
 The rate at which information is transferred, measured in bytes per second.
 
 ##### Bus
-A communications system that transfers data. A "Bus" includes hardware, software and the protocol.
+A communications system that transfers data. A "Bus" includes hardware, software, and the protocol.
 
 ##### Expander
 A device that provides additional inputs and/or outputs.
@@ -120,7 +120,7 @@ Self-hosted implementations must ensure that no internal properties or methods a
 <!--
 ### Immutability
 
-Immutability of object properties is a feature of ECMAScript. It is not widely used, however. Immutability is valuable for embedded systems and consequently this standard makes use of it in several ways.
+Immutability of object properties is a feature of ECMAScript. It is not widely used, however. Immutability is valuable for embedded systems and consequently, this standard makes use of it in several ways.
 
 - Data may be stored in read-only memory, reducing the RAM required for execution
 - Improving security as they are inherently resistant to tampering
@@ -252,7 +252,7 @@ The options object contains the specification of the hardware resources to be us
 
 If the constructor requires a resource that is already in use — whether by a script or the native host — an `Error` exception is thrown.
 
-This standard allows, but does not require, an implementation to open multiple instances for the same hardware resource if the instances cannot interfere with each other's operation. For example, this can work for a digital input but would not for a digital output.
+This standard allows but does not require, an implementation to open multiple instances for the same hardware resource if the instances cannot interfere with each other's operation. For example, this can work for a digital input but would not for a digital output.
 
 The IO Class Pattern is designed to be used both with IO types that have only a current value (e.g. Digital, analog, PWM) and IO types that use streams of data (e.g. serial, SPI).
 
@@ -280,7 +280,7 @@ If this instance does not support writing (because the IO type cannot be written
 
 The `format` property is a string that indicates the type of data used by the `read` and `write` methods. It is initialized by the constructor to the default defined for its IO type. The `format` property may be set by the script at any time to change how it reads and writes data.
 
-The following values are defined by the IO Class Pattern for the `format` property. IO types may choose to support one or more, and may define others.
+The following values are defined by the IO Class Pattern for the `format` property. IO types may choose to support one or more and may define others.
 
 - `number` - an ECMAScript number value, typically used for bytes
 - `buffer` - an `ArrayBuffer` instance
@@ -479,11 +479,11 @@ Writes the unsigned 8-bit integer `value` to the specified register.
 
 **`readUint16(register[, bigEndian])`**
 
-Reads and returns an unsigned 16-bit integer value from the specified register. By default the value is read in little-endian byte order. If the optional `bigEndian` argument is `true` the value is read in big-endian byte order.
+Reads and returns an unsigned 16-bit integer value from the specified register. By default, the value is read in little-endian byte order. If the optional `bigEndian` argument is `true` the value is read in big-endian byte order.
 
 **`writeUint16(register, value[, bigEndian])`**
 
-Writes the unsigned 16-bit integer value to the specified register. By default the value is written in little-endian byte order. If the optional `bigEndian` argument is `true` the value is written in big-endian byte order.
+Writes the unsigned 16-bit integer value to the specified register. By default, the value is written in little-endian byte order. If the optional `bigEndian` argument is `true` the value is written in big-endian byte order.
 
 **`readBuffer(register, buffer)`**
 
@@ -493,7 +493,7 @@ Reads a stream of bytes starting at the specified `register` into the `ArrayBuff
 
 Write a stream of bytes from the `ArrayBuffer` instance in the `buffer` argument starting at the specified `register`. The number of bytes read is equal to the `byteLength` of the buffer.
 
-> **Note**: The SMBus standard also defines 32 and 64 bit operations. The method names `readUint32`, `writeUint32`, `readUint64` and `writeUint64` are reserved to support these in the future. 
+> **Note**: The SMBus standard also defines 32 and 64-bit operations. The method names `readUint32`, `writeUint32`, `readUint64`, and `writeUint64` are reserved to support these in the future. 
 
 ### Serial
 The `Serial` class implements bi-directional serial (UART) communication.
@@ -558,7 +558,7 @@ The `onWritable` callback is first invoked when the serial instance is ready for
 The `onWritable` callback is invoked when space has been freed in the output buffer. The callback receives a single argument that indicates the number of bytes that may be written without overflowing the output buffer.
 
 #### Data format
-The `Serial` class data format is either `number` for individual bytes, or `buffer` for groups of bytes. The default data format is `number`. When using the `buffer` format, the `write` call accepts an `ArrayBuffer` or a `TypedArray`, and the `read` call always returns an `ArrayBuffer`.
+The `Serial` class data format is either `number` for individual bytes or `buffer` for groups of bytes. The default data format is `number`. When using the `buffer` format, the `write` call accepts an `ArrayBuffer` or a `TypedArray`, and the `read` call always returns an `ArrayBuffer`.
 
 ### Serial Peripheral Interface (SPI)
 
@@ -647,7 +647,7 @@ The `write` method sets the current count.
 The `onReadable` callback is invoked when the value of the counter has changed. Multiple changes to the counter may be combined into a single invocation of the callback.
 
 **`onError()`**
-The `onError ` callback is invoked when an error is detected, for example underflow or overflow of the counter.
+The `onError ` callback is invoked when an error is detected, for example, underflow or overflow of the counter.
 
 
 ### TCP cocket
@@ -667,7 +667,7 @@ The TCP socket is not a TCP listener, as in some networking libraries. The TCP l
 | `port` | A number specifying the remote port to connect to. This property is required.
 | `noDelay` | A boolean indicating whether to disable Nagle's algorithm on the socket. This property is equivalent to the `TCP_NODELAY` option in the BSD sockets API. This property is optional and defaults to false.
 | `keepAlive` | A number specifying the keep-alive interval of the socket in milliseconds. This property is optional and if not present, the keep-alive capability of the socket is not used.
-| `from` | An existing TCP socket instance from which the native socket instance is taken to use with the newly created socket instance. This property is optional and intended for use with a TCP listener. When the `from` property is present, the `address`, `host`, and `port` properties are not required, and are ignored if specified. The original instance is closed with ownership of the native socket transferred to the new instance.
+| `from` | An existing TCP socket instance from which the native socket instance is taken to use with the newly created socket instance. This property is optional and intended for use with a TCP listener. When the `from` property is present, the `address`, `host`, and `port` properties are not required and are ignored if specified. The original instance is closed with ownership of the native socket transferred to the new instance.
 
 #### Callbacks
 
@@ -793,7 +793,7 @@ Here the `data` and `clock` pins passed to the `Expander` constructor refer to p
 
 Following the Base Class Pattern, the constructor has a single options object argument. The options object defines the hardware connections of the sensor. These use the same properties as the IO types corresponding to the hardware connection. As in the Peripheral Class Pattern, the IO properties in the Provider Class Pattern are grouped to avoid collisions.
 
-The options object is not limited to IO connection information, and must contain all information needed by the implementation to establish the connection.
+The options object is not limited to IO connection information and must contain all information needed by the implementation to establish the connection.
 
 ### `close` method
 In addition to releasing all resources as required by the Base Class Pattern, the `close` method causes the `onError` callback to be invoked on all open instances. Note that `onError` may not be invoked from within `close` (see Callbacks section).
@@ -812,7 +812,7 @@ The IO constructors of an IO Provider, if present on the instance, may be used p
 
 The `onError` callback is invoked on a non-recoverable error to indicate that the provider instance can no longer be used.
 
-When a provider fails, its IO instances also become unusable and consequently `onError` must also be invoked on each instance.
+When a provider fails, its IO instances also become unusable, and consequently `onError` must also be invoked on each instance.
 
 ## 12 Peripheral Class Pattern
 
@@ -951,7 +951,7 @@ If the sample data includes timestamps (e.g. when the sample was collected), tho
 
 ### Callbacks
 
-The Sensor Class Pattern specifies one callback that is set by the options object passed to the constructor. Individual sensor classes may provide additional callbacks, for instance to indicate when a sample is available or a sensed condition has been met.
+The Sensor Class Pattern specifies one callback that is set by the options object passed to the constructor. Individual sensor classes may provide additional callbacks, for instance, to indicate when a sample is available or a sensed condition has been met.
 
 **`onError()`**
 
@@ -1157,9 +1157,9 @@ function adaptInvalid(options) {
 
 ### Instance properties
 
-**`width`** The width of the display in pixels as a number. This property is read-only. This value may change based on the configuration, for example when changing orientation from portrait to landscape. 
+**`width`** The width of the display in pixels as a number. This property is read-only. This value may change based on the configuration, for example, when changing orientation from portrait to landscape. 
 
-**`height`** The height of the display in pixels as a number. This property is read-only. This value may change based on the configuration, for example when changing orientation from portrait to landscape. 
+**`height`** The height of the display in pixels as a number. This property is read-only. This value may change based on the configuration, for example, when changing orientation from portrait to landscape. 
 
 ### Pixel `format` values
 

--- a/docs/tc53.md
+++ b/docs/tc53.md
@@ -109,7 +109,7 @@ This standard is intended to facilitate multiple independent implementations of 
 
 ### Self-hosting
 
-The ECMAScript language is defined in terms of a host that provides the runtime environment for execution of scripts. This standard does not change that. The APIs defined herein are provided by a host. However, this standard does anticipate that portions of the runtime environment provided by the host may themselves be implemented in ECMAScript. This standard refers to a host that includes some ECMAScript code in its implementation as self-hosting.
+The ECMAScript language is defined in terms of a host that provides the runtime environment for the execution of scripts. This standard does not change that. The APIs defined herein are provided by a host. However, this standard does anticipate that portions of the runtime environment provided by the host may themselves be implemented in ECMAScript. This standard refers to a host that includes some ECMAScript code in its implementation as self-hosting.
 
 One challenge of self-hosting is keeping the host fully separated from the scripts, to avoid problems including security, robustness, and compatibility. The Compartment model defined as part of the Secure ECMAScript proposal provides a solution for separating host scripts and hosted scripts.
 
@@ -138,11 +138,11 @@ A namespace prefix is used to minimize the chance of name collisions with other 
 
 The use of module namespaces in this standard is intended to be compatible with the [Built In Modules Proposal](https://github.com/tc39/proposal-built-in-modules#namespace).
 
-For avoidance of doubt, the use of bare module specifiers by this standard does not prevent a host from also supporting other kinds of module specifiers.
+For the avoidance of doubt, the use of bare module specifiers by this standard does not prevent a host from also supporting other kinds of module specifiers.
 
 ### Secure ECMAScript
 
-Secure ECMAScript (SES) is a proposal to extend the ECMAScript language to support provably secure execution of scripts in an environment that includes both trusted and untrusted scripts. The two foundations of Secure ECMAScript are immutability and compartments. SES makes all primordials immutable prior to execution of any untrusted script code. This ensures built-in objects behave as defined by the language, disables common attack vectors, and eliminates communication side-channels. Compartments allow scripts to sandbox other scripts to limit the globals and modules that are available in the sandbox.
+Secure ECMAScript (SES) is a proposal to extend the ECMAScript language to support provably secure execution of scripts in an environment that includes both trusted and untrusted scripts. The two foundations of Secure ECMAScript are immutability and compartments. SES makes all primordials immutable prior to the execution of any untrusted script code. This ensures built-in objects behave as defined by the language, disables common attack vectors, and eliminates communication side-channels. Compartments allow scripts to sandbox other scripts to limit the globals and modules that are available in the sandbox.
 
 The security guarantees provided by SES are valuable for building large systems that contain code from many sources, not all of which may be fully trusted. The mechanisms proposed by SES allow for an efficient implementation. Further, the immutability requirement for SES allows primordials to be stored in read-only memory, reducing RAM use and enabling them to be securely shared by multiple virtual machines.
 


### PR DESCRIPTION
Please look closely at 3db7b53 I managed to convince myself that there were valid situations where "IO Provider", "IO Providers", and "IO Provider's" all made sense in context, but each had a subtly different meaning.

None of these are things I feel strongly about so feel free to cherry-pick without worrying about what I think 😃 