### PR TITLE
Remove redundant reference section from Provenance TR

### DIFF
--- a/docs/Technical Reports/provenance.md
+++ b/docs/Technical Reports/provenance.md
@@ -28,7 +28,7 @@ This document is non-normative and intended to provide TC53 practitioners with g
 ## References<a name="references"></a>
 The following documents are referred to in the text in such a way that some or all of their content constitutes requirements of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.
 
-[1] ECMA-4xx, ECMAScript® Embedded Systems API Specification, 1st Edition (June 2021)
+[1] ECMA-4xx, ECMAScript® Embedded Systems API Specification
 
 ## Terms and Definitions<a name="termsanddefs"></a>
 For the purposes of this document, the terms and definitions from [1] apply.

--- a/docs/Technical Reports/provenance.md
+++ b/docs/Technical Reports/provenance.md
@@ -28,7 +28,7 @@ This document is non-normative and intended to provide TC53 practitioners with g
 ## References<a name="references"></a>
 The following documents are referred to in the text in such a way that some or all of their content constitutes requirements of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.
 
-[1] ECMA TC53, ECMAScript® Embedded Systems API Specification
+[1] ECMA-4xx, ECMAScript® Embedded Systems API Specification, 1st Edition (June 2021)
 
 ## Terms and Definitions<a name="termsanddefs"></a>
 For the purposes of this document, the terms and definitions from [1] apply.
@@ -66,11 +66,6 @@ If a connected sensing device generates a synthetic measurement, that measuremen
 If data stemming from a connected sensing device transits through intermediate data handlers, then that chain of stewardship may be queryable. 
 
 If a connected sensing device makes efforts to ensure trust and integrity of its derivative provenance data, then associated meta-provenance data related to trust and integrity in the provenance chain may be queryable. 
-
-# References
-For  dated  references,  only  the  edition  cited  applies.  For  undated  references,  the  latest  edition  of  the  referenced document (including any amendments) applies. 
-
-[1] ECMA-4xx, ECMAScript® Embedded Systems API Specification, 1st Edition (June 2021)
 
 <a id="copyright"></a>
 ## Copyright


### PR DESCRIPTION
Remove redundant reference section from provenance TR. 