### PR TITLE
Hardware Component document updates

### DIFF
--- a/docs/Hardware Components/displays/ILITEK-ILI9341.md
+++ b/docs/Hardware Components/displays/ILITEK-ILI9341.md
@@ -7,12 +7,12 @@ This document defines the ECMAScript class supporting the ILI9341 single-chip SO
 
 ## 2 Conformance
 
-This class specification conforms to the Display Class Pattern of ECMA-4xx, ECMAScript® Embedded Systems API Specification.
+This class specification conforms to the Display Class Pattern of ECMA-419, ECMAScript® Embedded Systems API Specification.
 
 ## 3 Normative References
 
 - [ILI9341 data sheet](https://www.crystalfontz.com/controllers/Ilitek/ILI9341/142/)
-- [ECMA-4xx, ECMAScript® Embedded Systems API Specification](https://EcmaTC53.github.io/spec/web/spec.html)
+- [ECMA-419, ECMAScript® Embedded Systems API Specification](https://419.ecma-international.org)
 
 ## 4 Notational Conventions
 

--- a/docs/Hardware Components/providers/Digital-Microchip-MCP23X08.md
+++ b/docs/Hardware Components/providers/Digital-Microchip-MCP23X08.md
@@ -7,12 +7,12 @@ This document defines the ECMAScript class supporting the MCP23008 and MCP24S08 
 
 ## 2 Conformance
 
-This class specification conforms to the IO Provider Class Pattern of ECMA-4xx, ECMAScript® Embedded Systems API Specification.
+This class specification conforms to the IO Provider Class Pattern of ECMA-419, ECMAScript® Embedded Systems API Specification.
 
 ## 3 Normative References
 
 - [MCP23X08 data sheet](http://ww1.microchip.com/downloads/en/DeviceDoc/MCP23008-MCP23S08-Data-Sheet-20001919F.pdf)
-- [ECMA-4xx, ECMAScript® Embedded Systems API Specification](https://EcmaTC53.github.io/spec/web/spec.html)
+- [ECMA-419, ECMAScript® Embedded Systems API Specification](https://419.ecma-international.org)
 
 ## 4 Notational Conventions
 
@@ -48,12 +48,12 @@ The `MCP23X08` IO Provider Class implements the IO Provider Class Pattern. This 
 
 ### `Digital` Class
 
-An instance of the `MCP23X08` IO Provider class contains a `Digital` IO class of ECMA-4xx, ECMAScript® Embedded Systems API Specification.
+An instance of the `MCP23X08` IO Provider class contains a `Digital` IO class of ECMA-419, ECMAScript® Embedded Systems API Specification.
 
 The `Digital.OutputOpenDrain` option is not available for the `mode` property in the options object passed to the provided Digital `constructor`. If `Digital.OutputOpenDrain` is specified to the `Digital` constructor, an `Error` exception is thrown. 
 
 ### `DigitalBank`  Class
 
-An instance of the `MCP23X08` IO Provider class contains a `DigitalBank` IO class of ECMA-4xx, ECMAScript® Embedded Systems API Specification.
+An instance of the `MCP23X08` IO Provider class contains a `DigitalBank` IO class of ECMA-419, ECMAScript® Embedded Systems API Specification.
 
 The `Digital.OutputOpenDrain` value is not supported for the `mode` property in the options object passed to the provided DigitalBank `constructor`. If `Digital.OutputOpenDrain` is specified to the `DigitalBank` constructor, an `Error` exception is thrown.

--- a/docs/Hardware Components/providers/Digital-Microchip-MCP23X17.md
+++ b/docs/Hardware Components/providers/Digital-Microchip-MCP23X17.md
@@ -7,12 +7,12 @@ This document defines the ECMAScript class supporting the MCP23017 and MCP24S17 
 
 ## 2 Conformance
 
-This class specification conforms to the IO Provider Class Pattern of ECMA-4xx, ECMAScript® Embedded Systems API Specification.
+This class specification conforms to the IO Provider Class Pattern of ECMA-419, ECMAScript® Embedded Systems API Specification.
 
 ## 3 Normative References
 
 - [MCP23X17 data sheet](https://ww1.microchip.com/downloads/en/DeviceDoc/20001952C.pdf)
-- [ECMA-4xx, ECMAScript® Embedded Systems API Specification](https://EcmaTC53.github.io/spec/web/spec.html)
+- [ECMA-419, ECMAScript® Embedded Systems API Specification](https://419.ecma-international.org)
 
 ## 4 Notational Conventions
 
@@ -56,12 +56,12 @@ The `MCP23X17` IO Provider Class implements the IO Provider Class Pattern. This 
 
 ### `Digital` Class
 
-An instance of the `MCP23X17` IO Provider class contains a `Digital` IO class of ECMA-4xx, ECMAScript® Embedded Systems API Specification.
+An instance of the `MCP23X17` IO Provider class contains a `Digital` IO class of ECMA-419, ECMAScript® Embedded Systems API Specification.
 
 The `Digital.OutputOpenDrain` option is not available for the `mode` property in the options object passed to the provided Digital `constructor`. If `Digital.OutputOpenDrain` is specified to the `Digital` constructor, an `Error` exception is thrown. 
 
 ### `DigitalBank`  Class
 
-An instance of the `MCP23X17` IO Provider class contains a `DigitalBank` IO class of ECMA-4xx, ECMAScript® Embedded Systems API Specification.
+An instance of the `MCP23X17` IO Provider class contains a `DigitalBank` IO class of ECMA-419, ECMAScript® Embedded Systems API Specification.
 
 The `Digital.OutputOpenDrain` value is not supported for the `mode` property in the options object passed to the provided DigitalBank `constructor`. If `Digital.OutputOpenDrain` is specified to the `DigitalBank` constructor, an `Error` exception is thrown.

--- a/docs/Hardware Components/sensors/AmbientLight-Proximity-STMicroelectronics-VL6180.md
+++ b/docs/Hardware Components/sensors/AmbientLight-Proximity-STMicroelectronics-VL6180.md
@@ -7,12 +7,12 @@ This document defines the ECMAScript class supporting the VL6180 time-of-flight 
 
 ## 2 Conformance
 
-This class specification conforms to the Ambient Light and Proximity Sensor Classes of ECMA-4xx, ECMAScript® Embedded Systems API Specification.
+This class specification conforms to the Ambient Light and Proximity Sensor Classes of ECMA-419, ECMAScript® Embedded Systems API Specification.
 
 ## 3 Normative References
 
 - [ST VL6180 data sheet](https://www.st.com/resource/en/datasheet/vl6180x.pdf)
-- [ECMA-4xx, ECMAScript® Embedded Systems API Specification](https://EcmaTC53.github.io/spec/web/spec.html)
+- [ECMA-419, ECMAScript® Embedded Systems API Specification](https://419.ecma-international.org)
 
 ## 4 Notational Conventions
 

--- a/docs/Hardware Components/sensors/AmbientLight-Proximity-STMicroelectronics-VL6180.md
+++ b/docs/Hardware Components/sensors/AmbientLight-Proximity-STMicroelectronics-VL6180.md
@@ -47,7 +47,7 @@ All of the following properties are optional.
 
 
 ### Properties of Sample Object
-`VL6180` extends the `AmbientLight` and `Proximity` sample objects to include the following properties.
+Samples returned from `VL6180` instances include the `lightmeter` and `proximity` objects defined, respectively, in the `AmbientLight` and `Proximity` Sensor Classes and the following additional properties.
 
 The instance can be configured to provide less information on each sample, as described above.
 
@@ -60,3 +60,12 @@ The instance can be configured to provide less information on each sample, as de
 | `moduleRevisionMinor` | A number indicating the module minor revision.
 | `manufacturedOn` | An object with properties `year`, `month`, `day`, `phase`, and `time` (all numbers) that indicate when the module was manufactured.
 | `identification` | A number indicating the identification code of the module.
+
+#### Inherited Properties from `AmbientLight` and `Proximity`
+
+| Property | Description |
+| :---: | :--- |
+| `lightmeter.illuminance` | A number that represents the sampled ambient light level in Lux.
+| `proximity.near` | A boolean that indicates if a proximate object is detected.
+| `proximity.distance` | A number that represents the distance to the nearest sensed object in centimeters or `null` if no object is detected.
+| `proximity.max` | A number that represents the maximum sensing range of the sensor in centimeters.

--- a/docs/Hardware Components/sensors/Temperature-TexasInstruments-TMP102.md
+++ b/docs/Hardware Components/sensors/Temperature-TexasInstruments-TMP102.md
@@ -47,8 +47,14 @@ Most property names were chosen to reference the configuration options described
 | `conversionRate` | Number specifying the TMP102 conversion rate in Hz. Must be one of `0.25`, `1`, `4`, or `8`. Initial value is `4`.
 
 ### Properties of Sample Object
-`TMP102` extends the `Temperature` sample object to include the following property.
+`TMP102` implements the sample object specified in the `Temperature` Sensor Class and extends it to include the following properties.
 
 | Property | Description |
 | :---: | :--- |
 | `alert` | Boolean indicating if a high temperature or low temperature alert has been asserted in the Configuration Register.
+
+#### Inherited Property from `Temperature`
+
+| Property | Description |
+| :---: | :--- |
+| `temperature` | A number that represents the sampled temperature in degrees Celsius.

--- a/docs/Hardware Components/sensors/Temperature-TexasInstruments-TMP102.md
+++ b/docs/Hardware Components/sensors/Temperature-TexasInstruments-TMP102.md
@@ -7,12 +7,12 @@ This document defines the ECMAScript class supporting the TMP102 temperature sen
 
 ## 2 Conformance
 
-This class specification conforms to the Temperature Sensor Class of ECMA-4xx, ECMAScript® Embedded Systems API Specification.
+This class specification conforms to the Temperature Sensor Class of ECMA-419, ECMAScript® Embedded Systems API Specification.
 
 ## 3 Normative References
 
 - [TI TMP102 data sheet](https://www.ti.com/lit/ds/symlink/tmp102.pdf)
-- [ECMA-4xx, ECMAScript® Embedded Systems API Specification](https://EcmaTC53.github.io/spec/web/spec.html)
+- [ECMA-419, ECMAScript® Embedded Systems API Specification](https://419.ecma-international.org)
 
 ## 4 Notational Conventions
 

--- a/docs/Hardware Components/sensors/Touch-FocalTech-FT6x06.md
+++ b/docs/Hardware Components/sensors/Touch-FocalTech-FT6x06.md
@@ -7,13 +7,13 @@ This document defines the ECMAScript class supporting the FT6x06 capacitive touc
 
 ## 2 Conformance
 
-This class specification conforms to the Touch Sensor Class of ECMA-4xx, ECMAScript® Embedded Systems API Specification.
+This class specification conforms to the Touch Sensor Class of ECMA-419, ECMAScript® Embedded Systems API Specification.
 
 ## 3 Normative References
 
 - [FocalTech FT6x06 data sheet](https://cdn-shop.adafruit.com/datasheets/FT6x06+Datasheet_V0.1_Preliminary_20120723.pdf)
 - [FocalTech FT6x06 application note and register map](https://cdn-shop.adafruit.com/datasheets/FT6x06_AN_public_ver0.1.3.pdf)
-- [ECMA-4xx, ECMAScript® Embedded Systems API Specification](https://EcmaTC53.github.io/spec/web/spec.html)
+- [ECMA-419, ECMAScript® Embedded Systems API Specification](https://419.ecma-international.org)
 
 ## 4 Notational Conventions
 

--- a/docs/Hardware Components/sensors/Touch-FocalTech-FT6x06.md
+++ b/docs/Hardware Components/sensors/Touch-FocalTech-FT6x06.md
@@ -49,7 +49,7 @@ All of the following properties are optional.
 ### Properties of Sample Object
 The `length` property of sample object has a range of `1` to `2`.
 
-`FT6X06` extends the `touch` object described in the `Touch` Sensor Class to include the following properties. 
+`FT6X06` implements the sample array specified in the `Touch` Sensor Class and extends the `touch` object described in the `Touch` Sensor Class to include the following properties. 
 
 | Property | Description |
 | :---: | :--- |
@@ -57,3 +57,11 @@ The `length` property of sample object has a range of `1` to `2`.
 | `area` | Number indicating the area of the touch. Range is `0` to `15`.
 
 These properties are included in the `touch` object only if `weight` and `area`, respectively, have been configured to `true` via the `configure` method. 
+
+##### Inherited Properties of `touch` Object from `Touch` Sensor Class
+
+| Property | Description |
+| :---: | :--- |
+| `x` | Number indicating the X coordinate of the touch point
+| `y` | Number indicating the Y coordinate of the touch point
+| `id` | Number indicating which touch point this entry corresponds to


### PR DESCRIPTION
This PR updates only the non-normative Hardware Component documents.

The changes are:

- update `sample` object descriptions to include inherited properties
- update ECMA-4xx references to ECMA-419 (including URL updates)

The `sample` object updates are to stay in-line with more recent discussions of the committee and to match upcoming additions to the Hardware Component repository.