### PR TITLE
Update 3x hardware component documents to use `sensor` property on the constructor's options object

### DIFF
--- a/docs/Hardware Components/sensors/Accelerometer-Magnetometer-STMicroelectronics-LSM303DLHC.md
+++ b/docs/Hardware Components/sensors/Accelerometer-Magnetometer-STMicroelectronics-LSM303DLHC.md
@@ -27,8 +27,10 @@ The `HMC5883` is at default I²C address of `0x1E`. The `LIS3DH` is at I²C addr
 
 ```
 let accelerometer = new LIS3DH({
-	address: 0x19,
-	...
+	sensor: {
+		address: 0x19,
+		...	
+	}
 });
 ```
 

--- a/docs/Hardware Components/sensors/AmbientLight-Proximity-STMicroelectronics-VL6180.md
+++ b/docs/Hardware Components/sensors/AmbientLight-Proximity-STMicroelectronics-VL6180.md
@@ -22,9 +22,11 @@ This class specification conforms to the Ambient Light and Proximity Sensor Clas
 
 The `VL6180` Sensor Class extends the `AmbientLight` and `Proximity` Sensor Classes with additional properties on the option objects passed to the `configure` method and returned by the `sample` method.
 
-### Properties of `constructor` Options Object
+#### Properties of `constructor` Options Object
 
-The `VL6180` constructor takes an `I2C` class constructor options object. The VL6180 has a default I²C address of `0x29` which will be used for `address` unless otherwise specified.
+| Property | Description |
+| :---: | :--- |
+| `sensor` | An `I2C` class constructor options object with the configuration to use for communication with the VL6180. This property is required. Its `hz` property defaults to `400_000` and its `address` property to `0x29`.
 
 ### Properties of `configure` Options Object
 

--- a/docs/Hardware Components/sensors/Touch-FocalTech-FT6x06.md
+++ b/docs/Hardware Components/sensors/Touch-FocalTech-FT6x06.md
@@ -27,7 +27,7 @@ The `FT6X06` Sensor Class extends the `Touch` Sensor Class with additional prope
 
 | Property | Description |
 | :---: | :--- |
-| `i2c` | An `I2C` class constructor options object with the configuration of the I2C controller connected to the FT6x06. This property is required.
+| `sensor` | An `I2C` class constructor options object with the configuration of the I2C controller connected to the FT6x06. This property is required.
 | `interrupt` | A `Digital` class constructor options object with the configuration of the FT6x06 interrupt pin. This property is required for instances that use the `onSample` callback.
 | `reset` | A `Digital` class constructor options object with the configuration of the FT6x06 reset pin. This property is optional. If present, a hardware reset is performed when the class is instantiated.
 | `onSample` | Callback to invoke when touch points are available from the `sample` method. This property is required if `interrupt` is provided.


### PR DESCRIPTION
Three sensors in the TR/109 repository did not follow the convention of using a property named `sensor` on the constructor's options object to provide the primary bus for the sensor. This PR corrects that for:
 - LSM303DLHC (which just had a typo in its document, as it referenced the LIS3DH constructor inaccurately) 
 - FT6x06
 - VL6180

These changes match updates to the implementations in the Moddable SDK.