### PR TITLE
Remove erroneously-added Barometer Sensor Class

### DIFF
--- a/docs/tc53.md
+++ b/docs/tc53.md
@@ -1287,18 +1287,6 @@ See Annex A for the [formal algorithms](#alg-sensor-atmospheric-pressure) of the
 | :---: | :--- |
 | `pressure` | A number that represents the sampled atmospheric pressure in Pascal. This property is required.
 
-### Barometer
-
-The `Barometer` class implements access to a barometric pressure sensor. The property name `barometer` is used when part of a compound sensor.
-
-See Annex A for the [formal algorithms](#alg-sensor-barometer) of the `Barometer` sensor class.
-
-#### Properties of a sample object
-
-| Property | Description |
-| :---: | :--- |
-| `pressure` | A number that represents the sampled barometric pressure in Pascal. This property is required.
-
 ### Carbon Dioxide Gas Sensor
 
 The `CarbonDioxideGasSensor` class implements access to a sensor that detects the amount of carbon dioxide in air. The property name `carbonDioxideGasSensor` is used when part of a compound sensor.


### PR DESCRIPTION
Barometer was not needed. The `AtmosphericPressure` Sensor Class approved in First Edition is correct. 