### PR TITLE
Simplify new sensor class names

### DIFF
--- a/docs/tc53.md
+++ b/docs/tc53.md
@@ -1290,11 +1290,11 @@ See Annex A for the [formal algorithms](#alg-sensor-atmospheric-pressure) of the
 | :---: | :--- |
 | `pressure` | A number that represents the sampled atmospheric pressure in Pascal. This property is required.
 
-### Carbon Dioxide Gas Sensor
+### Carbon Dioxide
 
-The `CarbonDioxideGasSensor` class implements access to a sensor that detects the amount of carbon dioxide in air. The property name `carbonDioxideGasSensor` is used when part of a compound sensor.
+The `CarbonDioxide` class implements access to a sensor that detects the amount of carbon dioxide in air. The property name `carbonDioxideDetector` is used when part of a compound sensor.
 
-See Annex A for the [formal algorithms](#alg-sensor-carbonDioxideGasSensor) of the `CarbonDioxideGasSensor` sensor class.
+See Annex A for the [formal algorithms](#alg-sensor-carbonDioxide) of the `CarbonDioxide` sensor class.
 
 #### Properties of a sample object
 
@@ -1302,11 +1302,11 @@ See Annex A for the [formal algorithms](#alg-sensor-carbonDioxideGasSensor) of t
 | :---: | :--- |
 | `CO2` | A number that represents the sampled carbon dioxide in parts per million. This property is required.
 
-### Carbon Monoxide Gas Sensor
+### Carbon Monoxide
 
-The `CarbonMonoxideGasSensor` class implements access to a sensor that detects the amount of carbon monoxide in air. The property name `carbonMonoxideGasSensor` is used when part of a compound sensor.
+The `CarbonMonoxide` class implements access to a sensor that detects the amount of carbon monoxide in air. The property name `carbonMonoxideDetector` is used when part of a compound sensor.
 
-See Annex A for the [formal algorithms](#alg-sensor-carbonMonoxideGasSensor) of the `CarbonMonoxideGasSensor` sensor class.
+See Annex A for the [formal algorithms](#alg-sensor-carbonMonoxide) of the `CarbonMonoxide` sensor class.
 
 #### Properties of a sample object
 
@@ -1314,11 +1314,11 @@ See Annex A for the [formal algorithms](#alg-sensor-carbonMonoxideGasSensor) of 
 | :---: | :--- |
 | `CO` | A number that represents the sampled carbon monoxide in parts per million. This property is required.
 
-### Dust Sensor
+### Dust
 
-The `DustSensor` class implements access to a sensor that detects the amount of dust suspended in air. The property name `dustSensor` is used when part of a compound sensor.
+The `Dust` class implements access to a sensor that detects the amount of dust suspended in air. The property name `dustDetector` is used when part of a compound sensor.
 
-See Annex A for the [formal algorithms](#alg-sensor-dustSensor) of the `DustSensor` sensor class.
+See Annex A for the [formal algorithms](#alg-sensor-dust) of the `Dust` sensor class.
 
 #### Properties of a sample object
 
@@ -1345,7 +1345,7 @@ The sign of the sampled angular velocity depends on the rotation direction, with
 
 ### Humidity
 
-The `Humidity` class implements access to a humidity sensor. The property name `hygrometer ` is used when part of a compound sensor.
+The `Humidity` class implements access to a humidity sensor. The property name `hygrometer` is used when part of a compound sensor.
 
 See Annex A for the [formal algorithms](#alg-sensor-humidity) of the `Humidity` sensor class.
 
@@ -1355,11 +1355,11 @@ See Annex A for the [formal algorithms](#alg-sensor-humidity) of the `Humidity` 
 | :---: | :--- |
 | `humidity` | A number that represents the sampled relative humidity as a percentage. This property is required.
 
-### Hydrogen Gas Sensor
+### Hydrogen
 
-The `HydrogenGasSensor` class implements access to a sensor that detects the amount of hydrogen in air. The property name `hydrogenGasSensor` is used when part of a compound sensor.
+The `Hydrogen` class implements access to a sensor that detects the amount of hydrogen in air. The property name `hydrogenDetector` is used when part of a compound sensor.
 
-See Annex A for the [formal algorithms](#alg-sensor-hydrogenGasSensor) of the `HydrogenGasSensor` sensor class.
+See Annex A for the [formal algorithms](#alg-sensor-hydrogen) of the `Hydrogen` sensor class.
 
 #### Properties of a sample object
 
@@ -1367,11 +1367,11 @@ See Annex A for the [formal algorithms](#alg-sensor-hydrogenGasSensor) of the `H
 | :---: | :--- |
 | `H` | A number that represents the sampled hydrogen in parts per million. This property is required.
 
-### Hydrogen Sulfide Gas Sensor
+### Hydrogen Sulfide
 
-The `HydrogenSulfideGasSensor` class implements access to a sensor that detects the amount of hydrogen sulfide in air. The property name `hydrogenSulfideGasSensor` is used when part of a compound sensor.
+The `HydrogenSulfide` class implements access to a sensor that detects the amount of hydrogen sulfide in air. The property name `hydrogenSulfideDetector` is used when part of a compound sensor.
 
-See Annex A for the [formal algorithms](#alg-sensor-hydrogenSulfideGasSensor) of the `HydrogenSulfideGasSensor` sensor class.
+See Annex A for the [formal algorithms](#alg-sensor-hydrogenSulfide) of the `HydrogenSulfide` sensor class.
 
 #### Properties of a sample object
 
@@ -1394,11 +1394,11 @@ These properties are compatible with the attributes of the same name in the [W3C
 | `y` | A number that represents the sampled magnetic field around the y axis in microtesla. This property is required.
 | `z` | A number that represents the sampled magnetic field around the z axis in microtesla. This property is required.
 
-### Methane Gas Sensor
+### Methane
 
-The `MethaneGasSensor` class implements access to a sensor that detects the amount of methane in air. The property name `methaneGasSensor` is used when part of a compound sensor.
+The `Methane` class implements access to a sensor that detects the amount of methane in air. The property name `methaneDetector` is used when part of a compound sensor.
 
-See Annex A for the [formal algorithms](#alg-sensor-methaneGasSensor) of the `MethaneGasSensor` sensor class.
+See Annex A for the [formal algorithms](#alg-sensor-methane) of the `Methane` sensor class.
 
 #### Properties of a sample object
 
@@ -1406,11 +1406,11 @@ See Annex A for the [formal algorithms](#alg-sensor-methaneGasSensor) of the `Me
 | :---: | :--- |
 | `CH4`| A number that represents the sampled methane in parts per million. This property is required.
 
-### Nitric Oxide Gas Sensor
+### Nitric Oxide
 
-The `NitricOxideGasSensor` class implements access to a sensor that detects the amount of nitric oxide in air. The property name `nitricOxideGasSensor` is used when part of a compound sensor.
+The `NitricOxide` class implements access to a sensor that detects the amount of nitric oxide in air. The property name `nitricOxideDetector` is used when part of a compound sensor.
 
-See Annex A for the [formal algorithms](#alg-sensor-nitricOxideGasSensor) of the `NitricOxideGasSensor` sensor class.
+See Annex A for the [formal algorithms](#alg-sensor-nitricOxide) of the `NitricOxide` sensor class.
 
 #### Properties of a sample object
 
@@ -1418,11 +1418,11 @@ See Annex A for the [formal algorithms](#alg-sensor-nitricOxideGasSensor) of the
 | :---: | :--- |
 | `NO` | A number that represents the sampled nitric oxide in parts per million. This property is required.
 
-### Nitric Dioxide Gas Sensor
+### Nitric Dioxide
 
-The `NitricDioxideGasSensor` class implements access to a sensor that detects the amount of nitric dioxide in air. The property name `nitricDioxideGasSensor` is used when part of a compound sensor.
+The `NitricDioxide` class implements access to a sensor that detects the amount of nitric dioxide in air. The property name `nitricDioxideDetector` is used when part of a compound sensor.
 
-See Annex A for the [formal algorithms](#alg-sensor-nitricDioxideGasSensor) of the `NitricDioxideGasSensor` sensor class.
+See Annex A for the [formal algorithms](#alg-sensor-nitricDioxide) of the `NitricDioxide` sensor class.
 
 #### Properties of a sample object
 
@@ -1430,11 +1430,11 @@ See Annex A for the [formal algorithms](#alg-sensor-nitricDioxideGasSensor) of t
 | :---: | :--- |
 | `NO2` | A number that represents the sampled nitric dioxide in parts per million. This property is required.
 
-### Oxygen Gas Sensor
+### Oxygen
 
-The `OxygenGasSensor` class implements access to a sensor that detects the amount of oxygen in air. The property name `oxygenGasSensor` is used when part of a compound sensor.
+The `Oxygen` class implements access to a sensor that detects the amount of oxygen in air. The property name `oxygenDetector` is used when part of a compound sensor.
 
-See Annex A for the [formal algorithms](#alg-sensor-oxygenGasSensor) of the `OxygenGasSensor` sensor class.
+See Annex A for the [formal algorithms](#alg-sensor-oxygen) of the `Oxygen` sensor class.
 
 #### Properties of a sample object
 
@@ -1442,11 +1442,11 @@ See Annex A for the [formal algorithms](#alg-sensor-oxygenGasSensor) of the `Oxy
 | :---: | :--- |
 | `O` | A number that represents the sampled oxygen in parts per million. This property is required.
 
-### Particulate Matter Sensor
+### Particulate Matter
 
-The `ParticulateMatterSensor` class implements access to a sensor that detects the amount of particulate matter suspended in air. The property name `particulateMatterSensor` is used when part of a compound sensor.
+The `ParticulateMatter` class implements access to a sensor that detects the amount of particulate matter suspended in air. The property name `particulateMatterDetector` is used when part of a compound sensor.
 
-See Annex A for the [formal algorithms](#alg-sensor-particulateMatterSensor) of the `ParticulateMatterSensor` sensor class.
+See Annex A for the [formal algorithms](#alg-sensor-particulateMatter) of the `ParticulateMatter` sensor class.
 
 #### Properties of a sample object
 
@@ -1469,11 +1469,11 @@ These properties are compatible with the attributes of the same name in the [W3C
 | `distance` | A number that represents the distance to the nearest sensed object in centimeters or `null` if no object is detected. This property is optional: some proximity sensors can only provide the `near` property. 
 | `max` | A number that represents the maximum sensing range of the sensor in centimeters.
 
-### Soil Moisture Sensor
+### Soil Moisture
 
-The `SoilMoistureSensor` class implements access to a soil moisture sensor. The property name `soilmoisturesensor` is used when part of a compound sensor.
+The `SoilMoisture` class implements access to a soil moisture detector. The property name `soilmoistureDetector` is used when part of a compound sensor.
 
-See Annex A for the [formal algorithms](#alg-sensor-soilmoisturesensor) of the `SoilMoistureSensor` sensor class.
+See Annex A for the [formal algorithms](#alg-sensor-soilmoisture) of the `SoilMoisture` sensor class.
 
 #### Properties of a sample object
 
@@ -1511,11 +1511,11 @@ The `Touch` class `sample` method returns an array of `touch` objects, as specif
 | `y` | Number indicating the Y coordinate of the touch point
 | `id` | Number indicating which touch point this entry corresponds to
 
-### VOC Sensor
+### Volatile Organic Compounds
 
-The `VOCSensor` class implements access to a sensor that detects the amount of volatile organic compounds suspended in air. The property name `vocSensor` is used when part of a compound sensor.
+The `VolatileOrganicCompounds` class implements access to a sensor that detects the amount of volatile organic compounds suspended in air. The property name `vocDetector` is used when part of a compound sensor.
 
-See Annex A for the [formal algorithms](#alg-sensor-vocSensor) of the `VOCSensor` sensor class.
+See Annex A for the [formal algorithms](#alg-sensor-VolatileOrganicCompounds) of the `VolatileOrganicCompounds` sensor class.
 
 #### Properties of a sample object
 


### PR DESCRIPTION
This PR simplifies the names of many of the new sensor classes added for Second Edition. The goal is to bring them more in line with the First Edition names, which generally only refer to the sensed quantity. 