### PR TITLE
fix(tc53): serial format defaults to number

### DIFF
--- a/docs/tc53.md
+++ b/docs/tc53.md
@@ -4,6 +4,10 @@
 
 <img src="../web/assets/ecma-logo.svg">
 
+## Changes since the second edition
+
+- Correct Serial data format default as `"buffer"` instead of `"number"`
+
 ## Introduction
 
 This Standard, ECMAScript Embedded Systems API Specification, defines APIs for use on embedded systems. Embedded systems are far more diverse than personal computers, smartphones, and web servers where ECMAScript is most widely used. The diversity of embedded hardware is a consequence of devices being optimized for a specific product or class of products.

--- a/docs/tc53.md
+++ b/docs/tc53.md
@@ -800,7 +800,7 @@ The `onWritable` callback is first invoked when the serial instance is ready for
 The `onWritable` callback is invoked when space has been freed in the output buffer. The callback receives a single argument that indicates the number of bytes that may be written without overflowing the output buffer.
 
 #### Data format
-The `Serial` class data format is either `"number"` for individual bytes or `"buffer"` for groups of bytes. The default data format is `"number"`.
+The `Serial` class data format is either `"number"` for individual bytes or `"buffer"` for groups of bytes. The default data format is `"buffer"`.
 
 ### Serial Peripheral Interface (SPI)
 


### PR DESCRIPTION
As I was reading through the spec and noticed the annex for the `Serial` IO class documented the default `format` to `"buffer"` when the main text documents:

> The Serial class data format is either "number" for individual bytes or "buffer" for groups of bytes. The default data format is "number".

`"number"` appears to be the default in the Moddable implementation as well. 

I'm not sure what the typical workflow is for corrections like this, so happy to make changes as needed. 