### PR TITLE
fix: tcp listener socket port argument is optional

### DIFF
--- a/docs/tc53.md
+++ b/docs/tc53.md
@@ -3389,7 +3389,7 @@ All properties from I²C.Async plus the following:
 
 | Property | Required | Range | Default |
 | :--- | :---: | :--- | :--- |
-| `port` | yes | 16-bit unsigned integer | |
+| `port` | no | 16-bit unsigned integer | 0 |
 | `address` | no | string | N/A |
 | `onError` | no | `null` or `Function` | `null` |
 | `onReadable` | no | `null` or `Function` | `null` |


### PR DESCRIPTION
The description of the TCP listener socket (`Listener` IO class) specifies that the `port` property of the constructor options object is optional. However, the algorithm section specifies the `port` property is required. 

The [Moddable implementation](https://github.com/Moddable-OpenSource/moddable/blob/public/modules/io/socket/lwip/tcp.c#L649-L662) follows the optional property logic and defaults the value to `0`. 

If we reference [other well-known implementations](https://nodejs.org/docs/latest/api/net.html#serverlistenport-host-backlog-callback):

> If port is omitted or is 0, the operating system will assign an arbitrary unused port

This appears to be the case in [lwIP TCP](https://www.nongnu.org/lwip/2_1_x/group__tcp__raw.html#gacf5aa67bd7fc66fef43f77a55a1201ee) as well. 