### PR TITLE
Introduce `subpath string`.

### DIFF
--- a/docs/tc53.md
+++ b/docs/tc53.md
@@ -2738,13 +2738,17 @@ The Files module provides operations for files, directories, and links.
 import files from "embedded:storage/files";
 ```
 
-The File module uses `/` as the path separator, regardless of the host. Multiple sequential path separators without an intervening name (e.g. `a//b.txt`) must be rejected. A path that begins with a path separator (e.g. `/a.txt`) must be rejected. The File module does not allow the special path specifiers `.` and `..`.
-
-The File module's default export is a [Directory instance](#storage-directory-class) for the file system root. Whether the file system root provided to scripts is the host's file system root is host-dependent.
+The Files module's default export is a [Directory instance](#storage-directory-class) for the file system root. Whether the file system root provided to scripts is the host's file system root is host-dependent.
 
 > **NOTE**: The Files module is designed to follow POSIX API semantics to allow direct implementation on POSIX and the many other environments that use POSIX as a model for their file APIs.
 
 > **NOTE**: For implementations of the Files module on POSIX, it is recommended that new files are created with `0666` permissions, new directories are created with `0777` permissions, and that directories are opened with `O_RDONLY` flags.
+
+<a id="storage-file-subpath">
+
+#### Subpath string
+
+The Files module Directory class methods often have a `path` argument, which must be a subpath string specifying a child of the current instance.  Subpath strings use `/` as the path separator, regardless of the host. Multiple sequential path separators without an intervening name (e.g. `a//b.txt`) must be rejected. A subpath string that begins with a path separator (e.g. `/a.txt`) must be rejected. The Files module does not allow the special path specifiers `.` and `..`.  Use an empty subpath string `""` to specify the current instance.
 
 <a id="storage-file-class"></a>
 
@@ -2804,11 +2808,11 @@ Conforms to the IO Class pattern's `close` method.
 
 ##### `openDirectory` method
 
-The `openDirectory` function instantiates a Directory instance from a directory path. It has a single argument, an options object. The following table enumerates the properties defined for the openFile options object:
+The `openDirectory` function instantiates a Directory instance from a directory subpath. It has a single argument, an options object. The following table enumerates the properties defined for the `openFile` options object:
 
 | Property | Description |
 | :---: | :--- |
-| `path` | A string indicating the name of the path of the directory to open. This property is required. 
+| `path` | A [subpath string](#storage-file-subpath) indicating the directory to open. This property is required. 
 
 The `openDirectory` function returns a Directory instance.
 
@@ -2823,11 +2827,11 @@ const network = settings.openDirectory({path: "network/wifi"});
 
 ##### `openFile` method
 
-The `openFile` function instantiates a File instance from a file path. It has a single argument, an options object. The following table enumerates the properties defined for the openFile options object:
+The `openFile` function instantiates a File instance from a file path. It has a single argument, an options object. The following table enumerates the properties defined for the `openFile` options object:
 
 | Property | Description |
 | :---: | :--- |
-| `path` | A string indicating the name of the path of the file to open. This property is required. 
+| `path` | A [subpath string](#storage-file-subpath) indicating the name of the path of the file to open. This property is required. 
 | `mode` | A string indicating the mode used access to the file. Values are `"r"`, `"r+"`, `"w"` , and `"w+"`. This property is optional and defaults to `"r"`.
 
 The `openFile` function returns a [File instance](#storage-file-class).
@@ -2843,7 +2847,7 @@ const help = documentation.openFile({path: "wifi/help.txt"});
 
 ##### `delete` method
 
-The `delete` method removes the file or directory specified by the first argument, a string.
+The `delete` method removes the file or directory specified by the first argument, a [subpath string](#storage-file-subpath).
 
 The `delete` method returns `true` if the file or directory is deleted and `false` if there is no file or directory at the path specified.
 
@@ -2851,7 +2855,7 @@ If the path is a directory, it must be empty or the `delete` method throws an `E
 
 ##### `move` method
 
-The `move` method moves and/or renames a file or directory. The first argument is a string indicating the path of the file or directory to move. The second argument is a string indicating the path to move the file or directory to. Both are relative to the directory instance, unless the optional third argument is provided which is another instance of Directory. In this case, the path of the second argument is resolved relative to the third argument.
+The `move` method moves and/or renames a file or directory. The first argument is a [subpath string](#storage-file-subpath) indicating the path of the file or directory to move. The second argument is a [subpath string](#storage-file-subpath) indicating the path to move the file or directory to. Both are relative to the directory instance, unless the optional third argument is provided which is another instance of Directory. In this case, the path of the second argument is resolved relative to the third argument.
 
 This example uses pass two arguments to move "network_update.json" from the root to the "settings" directory and rename it "network.json":
 
@@ -2872,7 +2876,7 @@ The three argument form is most useful when a host uses Directory instances to l
 
 ##### `status` method
 
-The `status` method returns a status instance with information about the file, directory, or link specified by the first argument, a string. The following table enumerates the properties defined for the returned status instance:
+The `status` method returns a status instance with information about the file, directory, or link specified by the first argument, a [subpath string](#storage-file-subpath). The following table enumerates the properties defined for the returned status instance:
 
 | Property | Description |
 | :---: | :--- |
@@ -2884,21 +2888,21 @@ The `status` method returns a status instance with information about the file, d
 
 ##### `createDirectory` method
 
-The `createDirectory` method creates a directory at the path specified by the first argument, a string.
+The `createDirectory` method creates a directory at the path specified by the first argument, a [subpath string](#storage-file-subpath).
 
 The `createDirectory` method returns `true` if the directory is successfully created and `false` if a directory already exists at the path specified.
 
 ##### `createLink` method
 
-The `createLink` method creates a link at the path specified by the first argument to the path specified by the second argument. Both arguments are strings.
+The `createLink` method creates a link at the path specified by the first argument to the path specified by the second argument. Both arguments are [subpath strings](#storage-file-subpath).
 
 ##### `readLink` method
 
-The `readLink` method resolves a link at the path specified by the first argument and returns the resolved path as a string. The resolved path should be within the root of the directory instance.
+The `readLink` method resolves a link at the path specified by the first argument [subpath string](#storage-file-subpath) and returns the resolved path as a string. The resolved path should be within the root of the directory instance.
 
 ##### `scan` method
 
-The `scan` method provides an iterator that enumerates the contents of a directory. The `scan` method has a single argument, a string indicating the path to scan. If the path resolves to a file or there is not a directory at the path, an `Error` instance is thrown. If the `scan` method is invoked with no arguments, it returns an iterator for the root of the directory instance.
+The `scan` method provides an iterator that enumerates the contents of a directory. The `scan` method has a single argument, a [subpath string](#storage-file-subpath) indicating the path to scan. If the path resolves to a file or there is not a directory at the path, an `Error` instance is thrown. If the `scan` method is invoked with no arguments, it returns an iterator for the root of the directory instance.
 
 The following example uses the `scan` method to iterate over the "settings" directory, outputting the names of the files.
 


### PR DESCRIPTION
Clarify the Files module's intention for the format for the `path` string.

Not necessary to merge verbatim; just consider the spirit of the change and see if you like it.

Best viewed without whitespace changes (my editor was putting in `^M` garbage for some reason).
